### PR TITLE
Ignore notifications

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,11 +51,16 @@ StreamProvider.prototype.isConnected = function(){
 StreamProvider.prototype._onResponse = function(response){
 
   const id = response.id
+  if (id === null || id === undefined) {
+    return
+  }
 
   const data = this._payloads[id]
-  if (!data) throw new Error(
-    `StreamProvider - Unknown response id for response: ${response}`
-  )
+  if (!data) {
+      throw new Error(
+      `StreamProvider - Unknown response id for response: ${response}`
+    )
+  }
 
   delete this._payloads[id]
   const callback = data[0]


### PR DESCRIPTION
Fixes unhandled case where a notification (response without id) is received by the `web3-stream-provider`. This makes the request/response handling more closely match that of the [inpage provider](https://github.com/MetaMask/core/blob/main/packages/json-rpc-middleware-stream/src/createStreamMiddleware.ts#L107-L110)

